### PR TITLE
Fix typo in CLI stdin test docstring

### DIFF
--- a/markitdown-main/packages/markitdown/tests/test_cli_vectors.py
+++ b/markitdown-main/packages/markitdown/tests/test_cli_vectors.py
@@ -103,7 +103,7 @@ def test_output_to_file(shared_tmp_dir, test_vector) -> None:
 
 @pytest.mark.parametrize("test_vector", CLI_TEST_VECTORS)
 def test_input_from_stdin_without_hints(shared_tmp_dir, test_vector) -> None:
-    """Test that the CLI readds from stdin correctly."""
+    """Test that the CLI reads from stdin correctly."""
 
     test_input = b""
     with open(os.path.join(TEST_FILES_DIR, test_vector.filename), "rb") as stream:


### PR DESCRIPTION
## Summary
- fix `readds` typo in `test_input_from_stdin_without_hints`

## Testing
- `python -m pytest markitdown-main/packages/markitdown/tests/test_cli_vectors.py::test_input_from_stdin_without_hints -q` *(fails: No module named pytest)*